### PR TITLE
german translation

### DIFF
--- a/src/DropIcons/Classes/Config.cs
+++ b/src/DropIcons/Classes/Config.cs
@@ -33,7 +33,7 @@ namespace DropIcons
             iniPath = isIntalled ? appdata + "\\Config.ini" : "Config.ini";
             iniLines = File.ReadAllLines(iniPath);
 
-            Console.WriteLine("Drop Icons is installed? " + isIntalled + " - ¿Drop Icons está instalado? " + isIntalled);
+            Console.WriteLine("Drop Icons is installed? " + isIntalled + " - ¿Drop Icons está instalado? " + isIntalled + " - Drop Icons ist installiert? " + isIntalled);
         }
 
         #region Language
@@ -56,9 +56,15 @@ namespace DropIcons
                     currentLan = "es";
                     selecLan = "es";
                     break;
+                    
+                case "Language = de":
+                    Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
+                    currentLan = "de";
+                    selecLan = "de";
+                    break;
             }
 
-            Console.WriteLine("Current language: " + currentLan + " - Idioma actual: " + currentLan);
+            Console.WriteLine("Current language: " + currentLan + " - Idioma actual: " + currentLan + " - Aktuelle Sprache: " + currentLan);
         }
 
         internal static void CheckLanguage()
@@ -70,21 +76,28 @@ namespace DropIcons
                 switch (selecLan)
                 {
                     case "en":
-                        iniLines[1] = iniLines[1].Replace("es", "en");
+                        iniLines[1] = iniLines[1].Replace("es", "en", "de");
                         File.WriteAllLines(iniPath, iniLines);
                         Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("");
                         currentLan = "en";
                         break;
 
                     case "es":
-                        iniLines[1] = iniLines[1].Replace("en", "es");
+                        iniLines[1] = iniLines[1].Replace("en", "es", "de");
                         File.WriteAllLines(iniPath, iniLines);
                         Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("es-419");
                         currentLan = "es";
                         break;
+                        
+                    case "de":
+                        iniLines[1] = iniLines[1].Replace("en", "es", "de");
+                        File.WriteAllLines(iniPath, iniLines);
+                        Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
+                        currentLan = "de";
+                        break;
                 }
 
-                Console.WriteLine("Selected language: " + selecLan + " - Idioma seleccionado: " + selecLan);
+                Console.WriteLine("Selected language: " + selecLan + " - Idioma seleccionado: " + selecLan + " - Gewählte Sprache: " + selecLan);
                 restart = true;
             }
         }
@@ -208,7 +221,7 @@ namespace DropIcons
                     break;
             }
 
-            Console.WriteLine("Format size: " + format + " - Formato de tamaño: " + format);
+            Console.WriteLine("Format size: " + format + " - Formato de tamaño: " + format + " - Formatgröße: " + format);
         }
         #endregion
     }

--- a/src/DropIcons/DropIcons.csproj
+++ b/src/DropIcons/DropIcons.csproj
@@ -195,6 +195,10 @@
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.es-419.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Include="Properties\Resources.de-DE.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.de-DE.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/src/DropIcons/MainWindow.xaml.cs
+++ b/src/DropIcons/MainWindow.xaml.cs
@@ -210,7 +210,7 @@ namespace DropIcons
 
             NoImages.Content = count;
             string no = bitmaps.Count.ToString();
-            Console.WriteLine(no + " Images to convert - " + no + " Imágenes para convertir");
+            Console.WriteLine(no + " Images to convert - " + no + " Imágenes para convertir - " + no + " Bilder zu konvertieren");
         }
 
         // Events: ↓ ↓ ↓
@@ -337,7 +337,7 @@ namespace DropIcons
                         Loading.Visibility = Visibility.Visible;
                         await Task.Delay(1);
                         SaveIcons(result);
-                        Console.WriteLine("Icons saved in " + result + " - Iconos guardados en " + result);
+                        Console.WriteLine("Icons saved in " + result + " - Iconos guardados en " + result + " - Symbole gespeichert unter " + result);
                         RemoveAll();
                         Loading.Visibility = Visibility.Hidden;
                     }
@@ -348,7 +348,7 @@ namespace DropIcons
         private void Reload_Click(object sender, RoutedEventArgs e)
         {
             RemoveAll();
-            Console.WriteLine("Images removed - Imágenes eliminadas");
+            Console.WriteLine("Images removed - Imágenes eliminadas - Bilder entfernt");
         }
 
         private void Exit_Click(object sender, RoutedEventArgs e)

--- a/src/DropIcons/Properties/Resources.Designer.cs
+++ b/src/DropIcons/Properties/Resources.Designer.cs
@@ -205,6 +205,15 @@ namespace DropIcons.Properties {
         }
         
         /// <summary>
+        ///   Busca una cadena traducida similar a Language: German.
+        /// </summary>
+        public static string LanguageGerman {
+            get {
+                return ResourceManager.GetString("LanguageGerman", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Busca una cadena traducida similar a Multiple.
         /// </summary>
         public static string Multiple {

--- a/src/DropIcons/Properties/Resources.de-DE.resx
+++ b/src/DropIcons/Properties/Resources.de-DE.resx
@@ -1,0 +1,186 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AddImages" xml:space="preserve">
+    <value>Bilder hinzufügen</value>
+  </data>
+  <data name="Images" xml:space="preserve">
+    <value>Bilder</value>
+  </data>
+  <data name="Image" xml:space="preserve">
+    <value>Bild</value>
+  </data>
+  <data name="ImageFiles" xml:space="preserve">
+    <value>Bilddateien</value>
+  </data>
+  <data name="ChooseSameFolder" xml:space="preserve">
+    <value>Gleichen Ordner auswählen</value>
+  </data>
+  <data name="GenerateTinyIcon" xml:space="preserve">
+    <value>Kleines Symbol erzeugen</value>
+  </data>
+  <data name="LanguageEnglish" xml:space="preserve">
+    <value>Sprache: Englisch</value>
+  </data>
+  <data name="ChangeTheme" xml:space="preserve">
+    <value>Thema ändern</value>
+  </data>
+  <data name="Options" xml:space="preserve">
+    <value>Optionen:</value>
+  </data>
+  <data name="About" xml:space="preserve">
+    <value>Über:</value>
+  </data>
+  <data name="LanguageEspañol" xml:space="preserve">
+    <value>Sprache: Spanisch</value>
+  </data>
+  <data name="LanguageGerman" xml:space="preserve">
+    <value>Sprache: Deutsch</value>
+  </data>
+  <data name="UtilityToConvertImagesToIcons" xml:space="preserve">
+    <value>Utility to convert images to icons (.ico) - v3.0.0</value>
+  </data>
+  <data name="onvert" xml:space="preserve">
+    <value>Konvertieren</value>
+  </data>
+  <data name="pply" xml:space="preserve">
+    <value>Übernehmen</value>
+  </data>
+  <data name="ancel" xml:space="preserve">
+    <value>Abbrechen</value>
+  </data>
+  <data name="AboutTitle" xml:space="preserve">
+    <value>Über</value>
+  </data>
+  <data name="DisableTopmost" xml:space="preserve">
+    <value>Im Vordergrund deaktivieren</value>
+  </data>
+  <data name="EnableTopmost" xml:space="preserve">
+    <value>Im Vordergrund aktivieren</value>
+  </data>
+  <data name="Icons" xml:space="preserve">
+    <value>Format</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Nächstes   🢖🢖</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>🢔🢔   Zurück</value>
+  </data>
+  <data name="Multiple" xml:space="preserve">
+    <value>Mehrere</value>
+  </data>
+</root>


### PR DESCRIPTION
Hopefully i didn't make a mistake with the code.

One question:
The strings for convert, apply and cancel don't have the starting letter.
The value of the strings in Resources.resx is just "onvert", "pply" and "ancel".
Is this the way it should be?

german translations:
Convert = Konvertieren OR Umwandeln
Apply = Übernehmen OR Anwenden
Cancel = Abbrechen

If the frist letter of the translated value of the strings must be cut off, then german translation isn't really possible.